### PR TITLE
Remove qualified icon for MMR ordering

### DIFF
--- a/src/components/views/Leaderboard.tsx
+++ b/src/components/views/Leaderboard.tsx
@@ -203,7 +203,7 @@ export function Leaderboard(props: Props) {
                         >
                           {entry.nickname}
                         </a>
-                        {entry.rank && entry.rank <= 4 ? (
+                        {order() !== LeaderboardOrder.MMR && entry.rank && entry.rank <= 4 ? (
                           <Tooltip content="Top 4 Qualify for EGC Open Tournament" class="text-xs text-gray-400">
                             <img src={EsoIcon} class="w-6 flex-none" />
                           </Tooltip>


### PR DESCRIPTION
I removed the EGC icon when ordering by MMR since it will be based on RP (and it would have been confusing to have different people designed as qualified depending of the ordering).

Maybe the best would have to base the icon always on RP rank but it seems that the API gives the rank based on the order we ask for.