### PR TITLE
Improve Leaderboard table spacings

### DIFF
--- a/src/components/views/Leaderboard.tsx
+++ b/src/components/views/Leaderboard.tsx
@@ -185,17 +185,17 @@ export function Leaderboard(props: Props) {
               <tbody>
                 {data()?.entries.map((entry) => (
                   <tr>
-                    <td class="px-4 md:pr-2 py-2 text-right text-gray-400 font-extrabold text-md md:text-lg border-b border-gray-700/50">
+                    <td class="px-1 md:px-4 py-2 text-right text-gray-400 font-extrabold text-md md:text-lg border-b border-gray-700/50">
                       {entry.rank}.
                     </td>
-                    <td class="min-w-8 border-b border-gray-700/50">
+                    <td class="pr-2 md:pr-4 min-w-10 border-b border-gray-700/50">
                       <img
                         src={entry.race === "infernals" ? infernals.src : vanguard.src}
                         alt={entry.race}
                         class="w-6 h-6"
                       />
                     </td>
-                    <td class="px-4 w-full truncate max-w-20 md:max-w-none pr-2 text-gray-50 font-bold  border-b border-gray-700/50">
+                    <td class="pr-2 md:pr-4 w-full truncate max-w-20 md:max-w-none text-gray-50 font-bold  border-b border-gray-700/50">
                       <div class="flex items-center gap-2">
                         <a
                           href={`/players/${entry.player_id}-${urlencode(entry.nickname!)}`}
@@ -212,7 +212,7 @@ export function Leaderboard(props: Props) {
                         )}
                       </div>
                     </td>
-                    <td class="pr-4 font-bold text-right text-sm text-gray-100  border-b border-gray-700/50">
+                    <td class="pr-2 md:pr-4 font-bold text-right text-sm text-gray-100  border-b border-gray-700/50">
                       <div class="flex items-center justify-end gap-1">
                         <span>
                           {order() !== LeaderboardOrder.MMR ? Math.round(entry.points || 0) : Math.round(entry.mmr)}
@@ -220,15 +220,15 @@ export function Leaderboard(props: Props) {
                         {order() !== LeaderboardOrder.MMR ? <RankedBadge entry={entry} class="min-w-8 w-4 md:w-8" /> : "MMR"}
                       </div>
                     </td>
-                    <td class="pr-4 text-gray-100 text-right text-sm border-b border-gray-700/50">
+                    <td class="pr-2 md:pr-4 text-gray-100 text-right text-sm border-b border-gray-700/50">
                       {entry.wins}
                       <span class="text-green-400"> W</span>
                     </td>
-                    <td class="pr-4 text-gray-100 text-right text-sm border-b border-gray-700/50">
+                    <td class="pr-2 md:pr-4 text-gray-100 text-right text-sm border-b border-gray-700/50">
                       {entry.losses}
                       <span class="text-red-400"> L</span>
                     </td>
-                    <td class="pr-4 text-right text-gray-100 text-sm border-b border-gray-700/50">
+                    <td class="pr-2 md:pr-4 text-right text-gray-100 text-sm border-b border-gray-700/50">
                       {Math.round((entry.win_rate <= 1 ? entry.win_rate * 100 : entry.win_rate) ?? 0)}%
                     </td>
                   </tr>

--- a/src/components/views/Leaderboard.tsx
+++ b/src/components/views/Leaderboard.tsx
@@ -185,17 +185,17 @@ export function Leaderboard(props: Props) {
               <tbody>
                 {data()?.entries.map((entry) => (
                   <tr>
-                    <td class="pr-0.5 md:pr-2 py-2 text-right text-gray-400 font-extrabold text-md md:text-lg border-b border-gray-700/50">
+                    <td class="px-4 md:pr-2 py-2 text-right text-gray-400 font-extrabold text-md md:text-lg border-b border-gray-700/50">
                       {entry.rank}.
                     </td>
-                    <td class="pr-0.5 md:pr-2 border-b border-gray-700/50">
+                    <td class="min-w-8 border-b border-gray-700/50">
                       <img
                         src={entry.race === "infernals" ? infernals.src : vanguard.src}
                         alt={entry.race}
                         class="w-6 h-6"
                       />
                     </td>
-                    <td class="truncate max-w-20 md:max-w-none pr-2 text-gray-50 font-bold  border-b border-gray-700/50">
+                    <td class="px-4 w-full truncate max-w-20 md:max-w-none pr-2 text-gray-50 font-bold  border-b border-gray-700/50">
                       <div class="flex items-center gap-2">
                         <a
                           href={`/players/${entry.player_id}-${urlencode(entry.nickname!)}`}
@@ -212,23 +212,23 @@ export function Leaderboard(props: Props) {
                         )}
                       </div>
                     </td>
-                    <td class="pr-1 font-bold text-right text-sm text-gray-100  border-b border-gray-700/50">
+                    <td class="pr-4 font-bold text-right text-sm text-gray-100  border-b border-gray-700/50">
                       <div class="flex items-center justify-end gap-1">
                         <span>
                           {order() !== LeaderboardOrder.MMR ? Math.round(entry.points || 0) : Math.round(entry.mmr)}
                         </span>
-                        {order() !== LeaderboardOrder.MMR ? <RankedBadge entry={entry} class="w-4 md:w-8" /> : "MMR"}
+                        {order() !== LeaderboardOrder.MMR ? <RankedBadge entry={entry} class="min-w-8 w-4 md:w-8" /> : "MMR"}
                       </div>
                     </td>
-                    <td class="pr-0.5 text-gray-100 text-right text-sm border-b border-gray-700/50">
+                    <td class="pr-4 text-gray-100 text-right text-sm border-b border-gray-700/50">
                       {entry.wins}
                       <span class="text-green-400"> W</span>
                     </td>
-                    <td class="pr-0.5 text-gray-100 text-right text-sm border-b border-gray-700/50">
+                    <td class="pr-4 text-gray-100 text-right text-sm border-b border-gray-700/50">
                       {entry.losses}
                       <span class="text-red-400"> L</span>
                     </td>
-                    <td class="pr-2 text-right text-gray-100 text-sm border-b border-gray-700/50">
+                    <td class="pr-4 text-right text-gray-100 text-sm border-b border-gray-700/50">
                       {Math.round((entry.win_rate <= 1 ? entry.win_rate * 100 : entry.win_rate) ?? 0)}%
                     </td>
                   </tr>

--- a/src/components/views/Leaderboard.tsx
+++ b/src/components/views/Leaderboard.tsx
@@ -195,11 +195,11 @@ export function Leaderboard(props: Props) {
                         class="w-6 h-6"
                       />
                     </td>
-                    <td class="pr-2 md:pr-4 w-full truncate max-w-20 md:max-w-none text-gray-50 font-bold  border-b border-gray-700/50">
+                    <td class="pr-2 md:pr-4 w-full max-w-20 md:max-w-none text-gray-50 font-bold  border-b border-gray-700/50">
                       <div class="flex items-center gap-2">
                         <a
                           href={`/players/${entry.player_id}-${urlencode(entry.nickname!)}`}
-                          class="outline-none hover:text-white focus:text-white"
+                          class="outline-none truncate hover:text-white focus:text-white"
                         >
                           {entry.nickname}
                         </a>
@@ -217,7 +217,11 @@ export function Leaderboard(props: Props) {
                         <span>
                           {order() !== LeaderboardOrder.MMR ? Math.round(entry.points || 0) : Math.round(entry.mmr)}
                         </span>
-                        {order() !== LeaderboardOrder.MMR ? <RankedBadge entry={entry} class="min-w-8 w-4 md:w-8" /> : "MMR"}
+                        {order() !== LeaderboardOrder.MMR ? (
+                          <RankedBadge entry={entry} class="min-w-8 w-4 md:w-8" />
+                        ) : (
+                          "MMR"
+                        )}
                       </div>
                     </td>
                     <td class="pr-2 md:pr-4 text-gray-100 text-right text-sm border-b border-gray-700/50">


### PR DESCRIPTION

![image](https://github.com/stormgateworld/web/assets/23478363/e5f9648b-d64e-4579-bd38-8ab5651ec679)


The main goal was to solve this issue where the first column width could be inconsistent. 

To solve it, I put full width on the "name" column so that it takes all the space it can. The other columns have the same sizes independently of the width of the names.
I adjusted the paddings to have a similar look.