### PR TITLE
Fix empty faction select

### DIFF
--- a/src/components/ui/SelectButton.tsx
+++ b/src/components/ui/SelectButton.tsx
@@ -12,6 +12,7 @@ export function SelectButton(props: {
   options: SelectButtonOption[]
   value: Accessor<SelectButtonOption>
   setValue: Setter<SelectButtonOption>
+  placeholder: string
   class?: string
 }) {
   const anyIcon = props.options.some((option) => option.icon)
@@ -24,6 +25,7 @@ export function SelectButton(props: {
       optionValue="value"
       optionTextValue="label"
       class={props.class}
+      placeholder={props.placeholder}
       itemComponent={(props) => (
         <Select.Item item={props.item} class={styles.dropdown.item}>
           <Select.ItemLabel class="flex items-center font-semibold">
@@ -35,6 +37,9 @@ export function SelectButton(props: {
               <></>
             )}
             {props.item.rawValue?.label}
+            <Select.ItemIndicator>
+              <span class="pl-4">✓</span>
+            </Select.ItemIndicator>
           </Select.ItemLabel>
         </Select.Item>
       )}

--- a/src/components/views/Leaderboard.tsx
+++ b/src/components/views/Leaderboard.tsx
@@ -25,7 +25,6 @@ interface Props {
 const perPage = 100
 
 const factionOptions: SelectButtonOption[] = [
-  { label: "All Factions", value: "all" },
   {
     label: "Infernals",
     value: Race.INFERNALS,
@@ -63,7 +62,7 @@ export function Leaderboard(props: Props) {
     on([selectedFaction, query], () =>
       start(() => {
         setPage(1)
-        setFaction(((f) => (f === "all" ? undefined : f))(selectedFaction()?.value as Race | "all"))
+        setFaction(selectedFaction()?.value as Race)
       })
     )
   )
@@ -128,6 +127,7 @@ export function Leaderboard(props: Props) {
               value={selectedFaction}
               setValue={setSelectedFaction}
               class="flex-auto sm:flex-none"
+              placeholder="All Factions"
             />
             <div class={styles.button.set}>
               <button


### PR DESCRIPTION
https://github.com/stormgateworld/web/issues/27

The issue was that there was 4 possibles states for the select: empty, all, infernal and vanguard.
The empty state that seems default in the library could be reached by re-selecting the same faction as described in the issue. 

The suggested change is to remove the "all" option from the select and use the "empty" option instead. 

I added a select indicator ✓ next to the selected faction to make it clearer to the user that to come back to "all" you need to select it again (since you don't have All Factions in the dropdown anymore).
Do you think it is user-friendly enough? Or should I find another way? 