### PR TITLE
Fix empty faction select

### DIFF
--- a/src/components/ui/SelectButton.tsx
+++ b/src/components/ui/SelectButton.tsx
@@ -24,6 +24,7 @@ export function SelectButton(props: {
       optionValue="value"
       optionTextValue="label"
       class={props.class}
+      disallowEmptySelection
       itemComponent={(props) => (
         <Select.Item item={props.item} class={styles.dropdown.item}>
           <Select.ItemLabel class="flex items-center font-semibold">


### PR DESCRIPTION
https://github.com/stormgateworld/web/issues/27

The issue was that there was 4 possibles states for the select: empty, all, infernal and vanguard.
The empty state that seems default in the library could be reached by re-selecting the same faction as described in the issue.

I disabled the empty selection state.