### PR TITLE
Fix issues on some screen sizes

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import "@fontsource-variable/nunito-sans"
 
 import Footer from "../components/Footer.astro"
+import { classes } from "../lib/theme"
 
 export interface Props {
   title: string
@@ -34,39 +35,39 @@ const navLinks = [
   </head>
   <body class="bg-body text-body font-body scroll-pt-24 bg-gray-950 text-white antialiased">
     <div class="sticky top-0 z-10 w-full border-b border-gray-700/50 bg-gray-800/80 backdrop-blur-md">
-      <nav
-        class="font-display mx-auto flex max-w-screen-2xl flex-wrap items-center gap-1 gap-y-2 px-1 py-2 md:h-16 md:gap-4 md:px-4"
-      >
+      <nav class="font-display mx-auto flex max-w-screen-2xl flex-wrap items-center gap-y-2 py-2 md:min-h-16 md:py-4">
         <a
           href="/"
-          class="basis-full whitespace-nowrap px-2 text-xl font-extrabold text-gray-200 md:basis-auto md:px-3"
+          class="basis-full whitespace-nowrap px-4 pr-2 text-xl font-extrabold text-gray-200 md:basis-auto md:px-7 md:pr-3"
         >
           Stormgate World</a
         >
 
-        {
-          navLinks.map(({ href, text }) => (
-            <a
-              href={href}
-              class:list={[
-                "font-bold rounded px-2 text-sm xs:text-base md:px-3 py-1 md:py-1.5",
-                currentRoute === href ? "bg-white/5 text-gray-50" : "hover:bg-white/5 text-gray-200 ",
-              ]}
-            >
-              {text}
-            </a>
-          ))
-        }
+        <div class="flex flex-auto flex-wrap gap-1 gap-y-2 pl-2 pr-4 md:gap-4 md:px-4 md:pr-7">
+          {
+            navLinks.map(({ href, text }) => (
+              <a
+                href={href}
+                class:list={[
+                  "font-bold rounded px-2 text-sm xs:text-base md:px-3 py-1 md:py-1.5",
+                  currentRoute === href ? "bg-white/5 text-gray-50" : "hover:bg-white/5 text-gray-200 ",
+                ]}
+              >
+                {text}
+              </a>
+            ))
+          }
 
-        <div class="flex-auto"></div>
-        <a
-          href="https://playstormgate.com"
-          target="_blank"
-          class="hidden whitespace-nowrap rounded-md border-white/20 bg-gray-100/20 px-6 py-2 text-sm font-bold text-gray-100 transition hover:bg-gray-100/30 sm:block"
-          data-class="bg-white rounded-full text-sm mr-4 px-6 py-2 border text-black my-6 inline-block font-bold border-white hover:bg-gray-100 transition"
-        >
-          Official Website
-        </a>
+          <div class="flex-auto"></div>
+          <a
+            href="https://playstormgate.com"
+            target="_blank"
+            class="hidden whitespace-nowrap rounded-md border-white/20 bg-gray-100/20 px-6 py-2 text-sm font-bold text-gray-100 transition hover:bg-gray-100/30 sm:block"
+            data-class="bg-white rounded-full text-sm mr-4 px-6 py-2 border text-black my-6 inline-block font-bold border-white hover:bg-gray-100 transition"
+          >
+            Official Website
+          </a>
+        </div>
       </nav>
     </div>
     <slot />

--- a/src/pages/stats.astro
+++ b/src/pages/stats.astro
@@ -66,7 +66,7 @@ const factions = [
 
 <Layout title="Statistics">
   <div class="w-full border-b border-gray-700/50 bg-gray-800/50 backdrop-blur-lg">
-    <div class="mx-auto flex max-w-screen-md flex-wrap items-center justify-between gap-4 px-4 py-8 md:px-0">
+    <div class="mx-auto flex max-w-screen-md flex-wrap items-center justify-between gap-4 px-4 py-8 md:px-7">
       <div>
         <p class="font-bold text-gray-500">Game</p>
         <h1 class="flex-auto text-2xl font-bold text-white">Statistics</h1>
@@ -76,8 +76,8 @@ const factions = [
       </p>
     </div>
   </div>
-  <div class="mx-auto w-full max-w-screen-md py-4 md:py-8">
-    <div class="flex justify-between px-4 py-4 md:px-0">
+  <div class="mx-auto w-full max-w-screen-md p-4 md:px-7 md:py-8">
+    <div class="flex justify-between py-4">
       <div>
         <h2 class="flex-auto text-2xl font-bold text-white">Factions</h2>
         <p class="text-gray-400">Excludes Mirrors.</p>

--- a/src/pages/tools.astro
+++ b/src/pages/tools.astro
@@ -35,14 +35,14 @@ const toolsContent: ToolContent[] = [
 
 <Layout title="Tools">
   <div class="w-full border-b border-gray-700/50 bg-gray-800/50 backdrop-blur-lg">
-    <div class="mx-auto flex max-w-screen-lg flex-wrap items-center justify-between gap-4 px-4 py-8 lg:px-0">
+    <div class="mx-auto flex max-w-screen-lg flex-wrap items-center justify-between gap-4 px-4 py-8 md:px-7">
       <div>
         <p class="font-bold text-gray-500">Community</p>
         <h1 class="flex-auto text-2xl font-bold text-white">Tools and Projects</h1>
       </div>
     </div>
   </div>
-  <div class="mx-auto w-full max-w-screen-lg px-8 py-4 md:py-8 lg:px-0">
+  <div class="mx-auto w-full max-w-screen-lg p-4 md:px-7 md:py-8">
     <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
       {toolsContent.map((c) => <Card data={c} />)}
     </div>


### PR DESCRIPTION
<img width="773" alt="Screenshot 2024-02-07 at 19 06 21" src="https://github.com/stormgateworld/web/assets/23478363/bd30a22c-ffa1-4262-9c84-cc4633411672">

I noticed some issues with the header and the paddings on the sides for the Stats and Tools pages for some of the screen sizes.

I did some changes to fix the header so that it wraps correctly and to make sure the paddings on the side are consistent (with padding = 4 for md or 2 below).

Here is how it looks like now:

<img width="691" alt="Screenshot 2024-02-07 at 19 34 07" src="https://github.com/stormgateworld/web/assets/23478363/d2bffe39-c710-4a5b-9b72-b9c15856c8cc">
<img width="875" alt="Screenshot 2024-02-07 at 19 35 31" src="https://github.com/stormgateworld/web/assets/23478363/e7bf8b06-a4ed-4104-8f0a-ad8c45a4093e">

Maybe there is a better/more sustainable solution by defining some wrapper components?