### PR TITLE
Remove last border leaderboard

### DIFF
--- a/src/components/views/Leaderboard.tsx
+++ b/src/components/views/Leaderboard.tsx
@@ -184,18 +184,18 @@ export function Leaderboard(props: Props) {
             >
               <tbody>
                 {data()?.entries.map((entry) => (
-                  <tr>
-                    <td class="text-md border-b border-gray-700/50 px-1 py-2 text-right font-extrabold text-gray-400 md:px-4 md:text-lg">
+                  <tr class="border-b border-gray-700/50 last:border-b-0">
+                    <td class="text-md  px-1 py-2 text-right font-extrabold text-gray-400 md:px-4 md:text-lg">
                       {entry.rank}.
                     </td>
-                    <td class="min-w-10 border-b border-gray-700/50 pr-2 md:pr-4">
+                    <td class="min-w-10 pr-2 md:pr-4">
                       <img
                         src={entry.race === "infernals" ? infernals.src : vanguard.src}
                         alt={entry.race}
                         class="h-6 w-6"
                       />
                     </td>
-                    <td class="w-full max-w-20 truncate border-b border-gray-700/50 pr-2 font-bold text-gray-50  md:max-w-none md:pr-4">
+                    <td class="w-full max-w-20 truncate pr-2 font-bold text-gray-50  md:max-w-none md:pr-4">
                       <div class="flex items-center gap-2">
                         <a
                           href={`/players/${entry.player_id}-${urlencode(entry.nickname!)}`}
@@ -212,7 +212,7 @@ export function Leaderboard(props: Props) {
                         )}
                       </div>
                     </td>
-                    <td class="border-b border-gray-700/50 pr-2 text-right text-sm font-bold  text-gray-100 md:pr-4">
+                    <td class=" pr-2 text-right text-sm font-bold  text-gray-100 md:pr-4">
                       <div class="flex items-center justify-end gap-1">
                         <span>
                           {order() !== LeaderboardOrder.MMR ? Math.round(entry.points || 0) : Math.round(entry.mmr)}
@@ -224,15 +224,15 @@ export function Leaderboard(props: Props) {
                         )}
                       </div>
                     </td>
-                    <td class="border-b border-gray-700/50 pr-2 text-right text-sm text-gray-100 md:pr-4">
+                    <td class=" pr-2 text-right text-sm text-gray-100 md:pr-4">
                       {entry.wins}
                       <span class="text-green-400"> W</span>
                     </td>
-                    <td class="border-b border-gray-700/50 pr-2 text-right text-sm text-gray-100 md:pr-4">
+                    <td class=" pr-2 text-right text-sm text-gray-100 md:pr-4">
                       {entry.losses}
                       <span class="text-red-400"> L</span>
                     </td>
-                    <td class="border-b border-gray-700/50 pr-2 text-right text-sm text-gray-100 md:pr-4">
+                    <td class="pr-2 text-right text-sm text-gray-100 md:pr-4">
                       {Math.round((entry.win_rate <= 1 ? entry.win_rate * 100 : entry.win_rate) ?? 0)}%
                     </td>
                   </tr>


### PR DESCRIPTION
Removes the last border of the leaderboard since it doesn't look very good. Also simplified the code.

<img width="1512" alt="Screenshot 2024-02-09 at 10 29 00" src="https://github.com/stormgateworld/web/assets/23478363/74eab6ab-2ae0-4ebf-af1f-2d5e667a8775">
 to 
<img width="1512" alt="Screenshot 2024-02-09 at 10 27 59" src="https://github.com/stormgateworld/web/assets/23478363/76a0e946-674f-4fb9-85bf-a57791cf3066">
