### PR TITLE
Improve widgets design

### DIFF
--- a/src/components/widgets/PlayerActivity.astro
+++ b/src/components/widgets/PlayerActivity.astro
@@ -62,7 +62,7 @@ function formatMonth(date: Date) {
 ---
 
 <Widget title="Activity" label={`${activity.aggregated?.matches ?? 0} Matches`}>
-  <div class="flex flex-row gap-1">
+  <div class="flex flex-row justify-center gap-1">
     {
       weeks.map((week, x) => (
         <div class="flex flex-col gap-1">

--- a/src/components/widgets/PlayerMatchupStats.astro
+++ b/src/components/widgets/PlayerMatchupStats.astro
@@ -16,19 +16,21 @@ const matchupsSortedByRace = playerMatchupStats.matchups.sort((a, b) => a.race.l
 ---
 
 <Widget title="Winrates by matchup">
-  <table class="mx-auto w-full table-auto whitespace-nowrap text-left text-sm transition-opacity">
+  <table class="mx-auto w-full table-auto whitespace-nowrap text-left transition-opacity">
     <tbody>
       {
         matchupsSortedByRace.map((matchup) => (
           <tr class="border-b border-gray-700/50 last:border-b-0">
-            <td class="flex w-full  gap-2 truncate p-2 font-semibold text-gray-50">
-              <Image src={matchup.race === "infernals" ? infernals : vanguard} alt={matchup.race} class="size-6" />
-              vs
-              <Image
-                src={matchup.opponent_race === "infernals" ? infernals : vanguard}
-                alt={matchup.opponent_race}
-                class="size-6"
-              />
+            <td class="w-full truncate p-2 font-semibold text-gray-50">
+              <div class="flex gap-2">
+                <Image src={matchup.race === "infernals" ? infernals : vanguard} alt={matchup.race} class="size-6" />
+                vs
+                <Image
+                  src={matchup.opponent_race === "infernals" ? infernals : vanguard}
+                  alt={matchup.opponent_race}
+                  class="size-6"
+                />
+              </div>
             </td>
             <td class="pr-2 text-right text-sm text-gray-100">
               {matchup.aggregated.wins_count}

--- a/src/components/widgets/PlayerOpponents.astro
+++ b/src/components/widgets/PlayerOpponents.astro
@@ -1,6 +1,5 @@
 ---
 import type { PlayerOpponentsStats } from "../../lib/api"
-import { classes } from "../../lib/theme"
 import Widget from "../Widget.astro"
 import { urlencode } from "../../lib/utils"
 
@@ -12,7 +11,7 @@ const { opponents } = Astro.props
 ---
 
 <Widget title="Top opponents">
-  <table class={classes("mx-auto w-full table-auto whitespace-nowrap text-left transition-opacity")}>
+  <table class="mx-auto w-full table-auto whitespace-nowrap text-left transition-opacity">
     <tbody>
       {
         opponents.opponents.map((opponent) => (
@@ -20,7 +19,7 @@ const { opponents } = Astro.props
             <td class="w-full truncate  p-2 font-semibold text-gray-50">
               <a
                 href={`/players/${opponent.player.player_id}-${urlencode(opponent.player.nickname!)}`}
-                class="truncat hover:underline"
+                class="truncate hover:underline"
               >
                 {opponent.player.nickname}
               </a>

--- a/src/pages/players/[id]-[username].astro
+++ b/src/pages/players/[id]-[username].astro
@@ -59,14 +59,16 @@ const highestLeague = player?.leaderboard_entries?.reduce(
         </div>
       </Widget>
     </div>
-    <div class="order-first flex basis-1/4 flex-col gap-6 sm:flex-row lg:order-none lg:flex-col">
+    <div
+      class="order-first flex basis-1/4 flex-col items-start justify-center gap-6 sm:flex-row lg:order-none lg:flex-col lg:items-stretch lg:justify-start"
+    >
       <Widget title="Top Ranks">
-        <div class="flex flex-col gap-2">
+        <div class="flex flex-col gap-2 px-2">
           {
             player.leaderboard_entries.map((entry) => (
               <div
                 class:list={[
-                  "rounded-lg pl-3 pr-1 py-2 -mx-2 flex items-center gap-3 text-sm sm:text-base",
+                  "rounded-lg px-4 py-2 -mx-2 flex items-center gap-3 text-sm sm:text-base justify-center",
                   styles.badges[entry.race as Theme].badge,
                 ]}
               >


### PR DESCRIPTION
I noticed some stuff that do not look that good for widget especially on mobile.
Tell me what you think.

Before:

<img width="1183" alt="Screenshot 2024-02-09 at 13 39 29" src="https://github.com/stormgateworld/web/assets/23478363/5089dc10-1f8d-4cfc-9350-8e161bb9b852">
<img width="832" alt="Screenshot 2024-02-09 at 13 40 00" src="https://github.com/stormgateworld/web/assets/23478363/a2f6f089-1b82-4825-94cf-eabc1cc47cd9">
<img width="574" alt="Screenshot 2024-02-09 at 13 40 26" src="https://github.com/stormgateworld/web/assets/23478363/79af48d0-e656-4b48-bc09-549d8f75bc2f">
<img width="574" alt="Screenshot 2024-02-09 at 13 40 53" src="https://github.com/stormgateworld/web/assets/23478363/223895c0-cd90-4f3e-9de8-c9587d58d324">
<img width="691" alt="Screenshot 2024-02-09 at 13 52 03" src="https://github.com/stormgateworld/web/assets/23478363/0ee89458-3037-43a9-a71b-f366653ac075">


After:

<img width="1183" alt="Screenshot 2024-02-09 at 13 39 25" src="https://github.com/stormgateworld/web/assets/23478363/dbee5f76-e416-4a91-8baf-9574dd37d6f9">
<img width="832" alt="Screenshot 2024-02-09 at 13 39 56" src="https://github.com/stormgateworld/web/assets/23478363/2104789e-4df0-4ec0-8676-072fe974e25f">
<img width="574" alt="Screenshot 2024-02-09 at 13 40 22" src="https://github.com/stormgateworld/web/assets/23478363/077015d9-5d78-45a7-8011-7c33ebe233aa">
<img width="574" alt="Screenshot 2024-02-09 at 13 40 56" src="https://github.com/stormgateworld/web/assets/23478363/e038504c-dac2-4c6c-876f-31208caa5589">
<img width="691" alt="Screenshot 2024-02-09 at 13 52 08" src="https://github.com/stormgateworld/web/assets/23478363/8f99fbb5-923a-4c3a-9154-35d32afba138">


It is mainly about centering some stuff. 
