### PR TITLE
Fix history shrinking icon

### DIFF
--- a/src/components/widgets/MatchPreview.astro
+++ b/src/components/widgets/MatchPreview.astro
@@ -26,71 +26,73 @@ const mainPlayer = match.players.find((player) => player.player?.player_id === m
   <!-- <div class="size-8 rounded bg-gray-600/50 border border-gray-500/60"></div> -->
   <div class="flex-auto">
     {
-      match.players.map((player, pos) => (
-        <div class="flex items-center gap-3">
-          <span
-            class:list={[
-              "w-8 flex-none text-xs whitespace-nowrap text-right",
-              player.mmr_diff! > 0 ? "text-green-500" : player.mmr_diff! < 0 ? "text-red-500" : "text-gray-500",
-            ]}
-          >
-            {player.mmr_diff! > 0 ? "↑" : "↓"}
-            {Math.abs(Math.round(player.mmr_diff!))}
-          </span>
-          <Tooltip content={player.race} client:idle>
-            <Image
-              src={player.race === "infernals" ? infernals : vanguard}
-              alt={player.race}
-              class="size-7 flex-none object-contain"
-            />
-          </Tooltip>
-          <div class:list={["flex flex-auto items-center gap-2 py-1.5", pos > 0 && "border-t border-gray-600/50"]}>
-            {player.player?.nickname ? (
-              <a
-                href={`/players/${player.player.player_id}-${urlencode(player.player.nickname!)}`}
-                class="truncate font-semibold text-gray-50 hover:underline"
-              >
-                {player.player.nickname}
-              </a>
-            ) : (
-              <em class="text-gray-300">Unknown</em>
-            )}
-            <div class="hidden text-sm md:block">
-              <span class="inline-flex items-center text-gray-500">
-                {player.player_leaderboard_entry ? (
-                  <>
-                    <RankedBadge entry={player.player_leaderboard_entry!} class="mr-1 w-4" client:idle />
-                    {`#${Math.round(player.player_leaderboard_entry?.rank!)} `} {Math.round(player.rating)}
-                  </>
-                ) : (
-                  <>
-                    <RankedBadge unranked class="mr-1 w-4" client:idle /> {Math.round(player.rating)}
-                  </>
-                )}
-              </span>
-            </div>
-            {player.scores?.resources_mined > 0 && (
-              <div class="hidden flex-auto justify-end gap-1.5 text-sm font-bold text-gray-100 xs:flex">
-                <Tooltip client:idle content="Total Units killed">
-                  {player.scores?.units_killed}
-                </Tooltip>
-                <span class="text-gray-600">/</span>
-                <Tooltip client:idle content="Total Structures Destroyed">
-                  {player.scores?.structures_killed}
-                </Tooltip>
-                <span class="text-gray-600">/</span>
-                <Tooltip client:idle content="Total Resources Mined">
-                  {Math.round(player.scores?.resources_mined / 100) / 10}k
-                </Tooltip>
-                <span class="text-gray-600">/</span>
-                <Tooltip client:idle content="Total Creep Resources Collected">
-                  {player.scores?.creep_resources_collected}
-                </Tooltip>
+      match.players
+        .sort((player) => (player.player?.player_id === mainPlayerId ? 1 : -1))
+        .map((player, pos) => (
+          <div class="flex items-center gap-3">
+            <span
+              class:list={[
+                "w-8 flex-none text-xs whitespace-nowrap text-right",
+                player.mmr_diff! > 0 ? "text-green-500" : player.mmr_diff! < 0 ? "text-red-500" : "text-gray-500",
+              ]}
+            >
+              {player.mmr_diff! > 0 ? "↑" : "↓"}
+              {Math.abs(Math.round(player.mmr_diff!))}
+            </span>
+            <Tooltip content={player.race} client:idle>
+              <Image
+                src={player.race === "infernals" ? infernals : vanguard}
+                alt={player.race}
+                class="size-7 min-w-7 flex-none object-contain"
+              />
+            </Tooltip>
+            <div class:list={["flex flex-auto items-center gap-2 py-1.5", pos > 0 && "border-t border-gray-600/50"]}>
+              {player.player?.nickname ? (
+                <a
+                  href={`/players/${player.player.player_id}-${urlencode(player.player.nickname!)}`}
+                  class="truncate font-semibold text-gray-50 hover:underline"
+                >
+                  {player.player.nickname}
+                </a>
+              ) : (
+                <em class="text-gray-300">Unknown</em>
+              )}
+              <div class="hidden text-sm md:block">
+                <span class="inline-flex items-center text-gray-500">
+                  {player.player_leaderboard_entry ? (
+                    <>
+                      <RankedBadge entry={player.player_leaderboard_entry!} class="mr-1 w-4" client:idle />
+                      {`#${Math.round(player.player_leaderboard_entry?.rank!)} `} {Math.round(player.rating)}
+                    </>
+                  ) : (
+                    <>
+                      <RankedBadge unranked class="mr-1 w-4" client:idle /> {Math.round(player.rating)}
+                    </>
+                  )}
+                </span>
               </div>
-            )}
+              {player.scores?.resources_mined > 0 && (
+                <div class="hidden flex-auto justify-end gap-1.5 text-sm font-bold text-gray-100 xs:flex">
+                  <Tooltip client:idle content="Total Units killed">
+                    {player.scores?.units_killed}
+                  </Tooltip>
+                  <span class="text-gray-600">/</span>
+                  <Tooltip client:idle content="Total Structures Destroyed">
+                    {player.scores?.structures_killed}
+                  </Tooltip>
+                  <span class="text-gray-600">/</span>
+                  <Tooltip client:idle content="Total Resources Mined">
+                    {Math.round(player.scores?.resources_mined / 100) / 10}k
+                  </Tooltip>
+                  <span class="text-gray-600">/</span>
+                  <Tooltip client:idle content="Total Creep Resources Collected">
+                    {player.scores?.creep_resources_collected}
+                  </Tooltip>
+                </div>
+              )}
+            </div>
           </div>
-        </div>
-      ))
+        ))
     }
   </div>
   <div class="hidden basis-1/6 text-right text-xs text-gray-400 sm:block">


### PR DESCRIPTION
Before:
<img width="636" alt="Screenshot 2024-02-11 at 10 28 03" src="https://github.com/stormgateworld/web/assets/23478363/5c29c26e-adf6-4fd3-9e3b-20448c862f5b">

After: 
<img width="636" alt="Screenshot 2024-02-11 at 10 28 20" src="https://github.com/stormgateworld/web/assets/23478363/a532d085-2414-458a-8c95-c50c9deed07b">

I fixed the race icon that was shrinking in the player's name was too long.
I also sorted players so make sure that the main player is always at the same spot to make things more consistent.

(You can select "hide whitespace" to help the review, to only highlight the changes I did)
