### PR TITLE
Add click to copy ID

### DIFF
--- a/src/components/layout/HeaderMeta.astro
+++ b/src/components/layout/HeaderMeta.astro
@@ -48,7 +48,7 @@ interface Props {
         )
         if (clickToCopy) {
           return (
-            <Tooltip content={tooltip} client:idle>
+            <Tooltip content={`${tooltip}\n(click to copy)`} client:idle>
               <ClickToCopy class="flex items-center gap-2" value={label} client:idle>
                 {content}
               </ClickToCopy>

--- a/src/components/layout/HeaderMeta.astro
+++ b/src/components/layout/HeaderMeta.astro
@@ -3,12 +3,14 @@ import Svg from "@jasikpark/astro-svg-loader"
 import { styles } from "../../lib/theme"
 import { Image } from "astro:assets"
 import { Tooltip } from "../ui/Tooltip"
+import { ClickToCopy } from "../ui/ClickToCopy"
 
 type MetaItem = {
   label: string
   icon?: Promise<typeof import("*.svg?raw")> | ImageMetadata
   tooltip?: string
   href?: string
+  clickToCopy?: boolean
 }
 interface Props {
   items?: MetaItem[]
@@ -24,9 +26,9 @@ interface Props {
     ]}
   >
     {
-      Astro.props.items?.map(({ label, icon, tooltip, href }) => (
-        <Tooltip content={tooltip} client:idle>
-          <div class="flex items-center gap-2">
+      Astro.props.items?.map(({ label, icon, tooltip, href, clickToCopy }) => {
+        const content = (
+          <>
             {icon && "src" in icon && <Image class="h-4 w-4  md:h-5 md:w-5" src={icon} alt="" />}
             {icon && icon instanceof Promise && <Svg class="h-4 w-4 text-white opacity-20 md:h-5 md:w-5" src={icon} />}
             <span class="text-xs font-bold text-white/40 md:text-sm">
@@ -42,9 +44,23 @@ interface Props {
                 label
               )}
             </span>
-          </div>
-        </Tooltip>
-      ))
+          </>
+        )
+        if (clickToCopy) {
+          return (
+            <Tooltip content={tooltip} client:idle>
+              <ClickToCopy class="flex items-center gap-2" value={label} client:idle>
+                {content}
+              </ClickToCopy>
+            </Tooltip>
+          )
+        }
+        return (
+          <Tooltip content={tooltip} client:idle>
+            <div class="flex items-center gap-2">{content}</div>
+          </Tooltip>
+        )
+      })
     }
   </div>
 </div>

--- a/src/components/ui/ClickToCopy.tsx
+++ b/src/components/ui/ClickToCopy.tsx
@@ -1,0 +1,39 @@
+import type { ParentComponent } from "solid-js"
+import { Toast, toaster } from "@kobalte/core"
+import { Portal } from "solid-js/web"
+import xIcon from "lucide-static/icons/x.svg?raw"
+
+export const ClickToCopy: ParentComponent<{ class?: string; value?: string }> = (props) => {
+  const onClick = async () => {
+    if (props.value) {
+      await navigator.clipboard.writeText(props.value)
+      showToast()
+    }
+  }
+
+  const showToast = () => {
+    toaster.show((props) => (
+      <Toast.Root toastId={props.toastId} class="rounded-md border-gray-500 bg-gray-800 p-4">
+        <div class="flex justify-around gap-2">
+          <Toast.Title class="font-bold text-gray-50">Copied to clipboard</Toast.Title>
+          <Toast.CloseButton>
+            <span innerHTML={xIcon} class="text-gray-200 *:w-4" />
+          </Toast.CloseButton>
+        </div>
+      </Toast.Root>
+    ))
+  }
+
+  return (
+    <>
+      <div class={props.class} onClick={onClick}>
+        {props.children}
+      </div>
+      <Portal>
+        <Toast.Region duration={2000}>
+          <Toast.List class="fixed bottom-0 right-0 flex w-64 flex-col gap-2 p-4" />
+        </Toast.Region>
+      </Portal>
+    </>
+  )
+}

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,5 +1,5 @@
-import { As, Tooltip as KTooltip } from "@kobalte/core"
-import { children, createEffect, createMemo, Show, type JSX, type ParentProps } from "solid-js"
+import { Tooltip as KTooltip } from "@kobalte/core"
+import { Show, type ParentProps } from "solid-js"
 
 export function Tooltip(props: ParentProps<{ content?: string; class?: string }>) {
   return (

--- a/src/layouts/PlayerLayout.astro
+++ b/src/layouts/PlayerLayout.astro
@@ -8,10 +8,9 @@ import { RankedBadge } from "../components/ui/RankedBadge"
 import HeaderMeta from "../components/layout/HeaderMeta.astro"
 import { formatDateRelative, getPlayerSlug } from "../lib/format"
 import type { PlayerResponse } from "../lib/api"
-import { getCollection, getEntry } from "astro:content"
+import { getCollection } from "astro:content"
 import { Image } from "astro:assets"
 import { Tooltip } from "../components/ui/Tooltip"
-import type { Code } from "astro:components"
 
 interface Props {
   player: PlayerResponse
@@ -88,7 +87,12 @@ const playerInfo = (await getCollection("players")).find((p) => p.data.playerId 
           icon: import("lucide-static/icons/activity.svg?raw"),
           label: `Last Match ${formatDateRelative(new Date(player.last_match_ended_at!))}`,
         },
-        { icon: import("lucide-static/icons/hash.svg?raw"), label: player.id, tooltip: "Stormgate World Player ID" },
+        {
+          icon: import("lucide-static/icons/hash.svg?raw"),
+          label: player.id,
+          tooltip: "Stormgate World Player ID",
+          clickToCopy: true,
+        },
         ...(playerInfo?.data.liquipediaUrl
           ? [
               {


### PR DESCRIPTION
Closes https://github.com/stormgateworld/web/issues/79

With tournament asking for your SGW id, I think it would be pretty handy to be able to click to copy.

I am not sure it is the best implementation so feel free to suggest any improvement. I tried to make the copy component easily reusable. 
Ideally, I would have liked a reusable Toast component but I am not sure how to handle this Portal thing in that case. If you have a good solution for that I can implement it!

<img width="1512" alt="Screenshot 2024-02-21 at 14 24 35" src="https://github.com/stormgateworld/web/assets/23478363/584107bd-6e8c-43b4-b2db-f718010837ed">
