### PR TITLE
Nitpick: center items in match preview

### DIFF
--- a/src/components/widgets/MatchPreview.tsx
+++ b/src/components/widgets/MatchPreview.tsx
@@ -58,7 +58,7 @@ export default function MatchPreview(props: { match: MatchResponse; mainPlayerId
                 ) : (
                   <em class="text-gray-300">Unknown</em>
                 )}
-                <div class="hidden text-sm md:block">
+                <div class="hidden items-center text-sm md:flex">
                   <span class="inline-flex items-center text-gray-500">
                     {player.player_leaderboard_entry ? (
                       <>


### PR DESCRIPTION
Vertically center the league icon and rank in the MatchPreview component, it is slightly above the center currently.