### PR TITLE
#70: Improve header visibility across browsers

### DIFF
--- a/src/components/layout/MainNav.astro
+++ b/src/components/layout/MainNav.astro
@@ -11,14 +11,9 @@ const navLinks = [
 ---
 
 <div
-  class="to-black-20 sticky top-0 z-10 h-20 w-full border-b border-white/5 bg-gradient-to-r from-black/40 via-black/25 mix-blend-screen backdrop-blur md:h-16"
+  class="to-black-10/10 via-black-20/10 sticky top-0 z-10 h-20 w-full border-b border-white/5 bg-gradient-to-r from-black/10 backdrop-blur md:h-16"
 >
-  <nav
-    class:list={[
-      styles.layout.container,
-      "flex flex-wrap md:flex-nowrap items-center gap-y-2 py-2 md:min-h-16 md:py-4",
-    ]}
-  >
+  <nav class:list={["flex flex-wrap md:flex-nowrap items-center gap-y-2 py-2 md:min-h-16 md:py-4 max-w-screen-xl"]}>
     <a
       href="/"
       class:list={[


### PR DESCRIPTION
See issue [70](https://github.com/stormgateworld/web/issues/70)

This makes minor adjustments to the header to improve visibility across browsers. The difference in chrome is negligible but there's good improvement for firefox and safari. 

- Removes `mix-blend-screen` and decreases the gradient darkness to compensate
- Removes `styles.layout.container` from `nav` to prevent `mx-auto` from breaking the horizontal alignment of the nav with the page's content (not sure if that was intended, feel free to revert)

Firefox Before
<img width="873" alt="firefox-before" src="https://github.com/stormgateworld/web/assets/40607888/23c9a725-e019-4887-95c9-f4b05bc91cad">

Firefox After
<img width="879" alt="Screenshot 2024-02-25 at 3 11 26 PM" src="https://github.com/stormgateworld/web/assets/40607888/86c05cc3-e527-4459-9a3a-444ad4976f1b">

Safari Before
<img width="1009" alt="safari-before" src="https://github.com/stormgateworld/web/assets/40607888/18e5479f-1714-4539-944d-562d4b0ea263">

Safari After
<img width="1016" alt="safari-after" src="https://github.com/stormgateworld/web/assets/40607888/8c65ee06-209a-4352-b08e-7f3b7f2ea1c4">

Chrome Before
<img width="1010" alt="chrome-before" src="https://github.com/stormgateworld/web/assets/40607888/7eff4a55-f650-4b17-a8de-52ccf44e1010">

Chrome After
<img width="1005" alt="chrome-after" src="https://github.com/stormgateworld/web/assets/40607888/ac2f3035-e3cf-4967-a728-707fa353fcc4">




